### PR TITLE
Corrected __init__.py

### DIFF
--- a/darklyrics/__init__.py
+++ b/darklyrics/__init__.py
@@ -1,3 +1,3 @@
 from .darklyrics import get_lyrics, get_all_lyrics, get_songs, get_albums, LyricsNotFound
 
-__all__ = ['get_lyrics', 'get_all_lyrics', 'get_albums', 'get_songs' 'LyricsNotFound']
+__all__ = ['get_lyrics', 'get_all_lyrics', 'get_albums', 'get_songs', 'LyricsNotFound']

--- a/darklyrics/__init__.py
+++ b/darklyrics/__init__.py
@@ -1,3 +1,3 @@
-from .darklyrics import get_lyrics, LyricsNotFound
+from .darklyrics import get_lyrics, get_all_lyrics, get_songs, get_albums, LyricsNotFound
 
-__all__ = ['get_lyrics', 'LyricsNotFound']
+__all__ = ['get_lyrics', 'get_all_lyrics', 'get_albums', 'get_songs' 'LyricsNotFound']

--- a/darklyrics/__init__.py
+++ b/darklyrics/__init__.py
@@ -1,3 +1,3 @@
-from .darklyrics import get_lyrics, LyricsNotFound
+from .darklyrics import get_lyrics, get_all_lyrics, get_songs, get_albums, LyricsNotFound
 
-__all__ = ['get_lyrics', 'LyricsNotFound']
+__all__ = ['get_lyrics', 'get_all_lyrics', 'get_albums', 'get_songs', 'LyricsNotFound']

--- a/tests/test_get_lyrics.py
+++ b/tests/test_get_lyrics.py
@@ -1,7 +1,6 @@
 import pytest
 
-from darklyrics import get_lyrics, LyricsNotFound
-from darklyrics.darklyrics import get_songs, get_all_lyrics, get_albums
+from darklyrics import get_lyrics, LyricsNotFound, get_albums, get_songs, get_all_lyrics
 
 
 def test_not_found():
@@ -9,29 +8,36 @@ def test_not_found():
         get_lyrics('fakesong', 'fakeartist')
         get_albums('fakeartist')
 
+
 def test_song_only():
     lyric = get_lyrics('your familiar face')
     assert 'but love is meaningless' in lyric.lower()
+
 
 def test_get_songs():
     songs = get_songs("katatonia")
     assert 'Criminals' in songs
 
+
 def test_get_songs_fail():
     with pytest.raises(LyricsNotFound):
         get_songs("fakeartist")
+
 
 def test_get_all_songs():
     lyrics = get_all_lyrics('in vain')
     assert 'Before it was torn by hands of man' in lyrics
 
+
 def test_integration():
     lyric = get_lyrics('steelheart', 'she\'s gone')
     assert 'i\'m to blame,' in lyric.lower()
 
+
 def test_get_albums():
     albums = get_albums('shadows fall')
     assert 'Retribution' in albums
+
 
 def test_get_albums_fail():
     with pytest.raises(LyricsNotFound):


### PR DESCRIPTION
In my last pull request, I was not aware that the interface to darkylrics.py is derived through __init__.py, where all externaly visible methods have to be declared. Therefore, one had to access the new methods by "import darklyrcis.darklyrics.get_all_lyrics" and so on, which is now gone.
Sorry for the overhead. ^^